### PR TITLE
dropped unused observer parameter

### DIFF
--- a/KVO Blocks/NSObject+KVOBlocks.h
+++ b/KVO Blocks/NSObject+KVOBlocks.h
@@ -12,13 +12,11 @@ typedef void (^KVOBlock)(NSDictionary *change, void *context);
 
 @interface NSObject (KVOBlocks)
 
-- (void)addObserver:(NSObject *)observer
-         forKeyPath:(NSString *)keyPath
-            options:(NSKeyValueObservingOptions)options
-            context:(void *)context
-          withBlock:(KVOBlock)block;
+- (void)addObserverForKeyPath:(NSString *)keyPath
+                      options:(NSKeyValueObservingOptions)options
+                      context:(void *)context
+                    withBlock:(KVOBlock)block;
 
-- (void)removeBlockObserver:(NSObject *)observer
-                 forKeyPath:(NSString *)keyPath;
+- (void)removeBlockObserverForKeyPath:(NSString *)keyPath;
 
 @end

--- a/KVO Blocks/NSObject+KVOBlocks.m
+++ b/KVO Blocks/NSObject+KVOBlocks.m
@@ -11,11 +11,10 @@
 
 @implementation NSObject (KVOBlocks)
 
-- (void)addObserver:(NSObject *)observer
-         forKeyPath:(NSString *)keyPath
-            options:(NSKeyValueObservingOptions)options
-            context:(void *)context
-          withBlock:(KVOBlock)block
+- (void)addObserverForKeyPath:(NSString *)keyPath
+                      options:(NSKeyValueObservingOptions)options
+                      context:(void *)context
+                    withBlock:(KVOBlock)block
 {
     objc_setAssociatedObject(self, (__bridge const void *)(keyPath), block, OBJC_ASSOCIATION_COPY);
     [self addObserver:self forKeyPath:keyPath options:options context:context];
@@ -30,8 +29,7 @@
     block(change, context);
 }
 
-- (void)removeBlockObserver:(NSObject *)observer
-                 forKeyPath:(NSString *)keyPath
+- (void)removeBlockObserverForKeyPath:(NSString *)keyPath
 {
     objc_setAssociatedObject(self, (__bridge const void *)(keyPath), nil, OBJC_ASSOCIATION_COPY);
     [self removeObserver:self forKeyPath:keyPath];


### PR DESCRIPTION
I noticed the `observer` parameter wasn't being used, so I dropped it from the methods.  It's hard to believe something so small can be so useful - thanks!
